### PR TITLE
fix(testing): cypress cannot be started in chrome headless mode

### DIFF
--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -155,7 +155,7 @@ function initCypress(
   }
 
   options.exit = exit;
-  options.headed = !headless;
+  options.headless = headless;
   options.record = record;
   options.key = key;
   options.parallel = parallel;


### PR DESCRIPTION
## Current Behavior (This is the behavior we have today, before the PR is merged)
Command `nx e2e --browser chrome --headless` is still running in chrome in headed mode

## Expected Behavior (This is the new behavior we can expect after the PR is merged)
Command `nx e2e --browser chrome --headless` is still running in chrome in headless mode

## Issue
#2614